### PR TITLE
Turn off -Wcast-function-type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,8 +8,11 @@ m4_ifdef([AC_USE_SYSTEM_EXTENSIONS],
     [AC_GNU_SOURCE])
 
 AC_PROG_CC_C99
+
 for flag in -Wall -Wextra; do
-  AC_TRY_COMPILE([], [return 0;], [CFLAGS="$CFLAGS $flag"],)
+  OLD_CFLAGS=$CFLAGS
+  CFLAGS="$CFLAGS $flag"
+  AC_TRY_COMPILE(, [return 0;], [], [CFLAGS=$OLD_CFLAGS])
 done
 
 AC_CANONICAL_SYSTEM

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ m4_ifdef([AC_USE_SYSTEM_EXTENSIONS],
 
 AC_PROG_CC_C99
 
-for flag in -Wall -Wextra; do
+for flag in -Wall -Wextra -Wno-cast-function-type; do
   OLD_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS $flag"
   AC_TRY_COMPILE(, [return 0;], [], [CFLAGS=$OLD_CFLAGS])


### PR DESCRIPTION
The glib event library forces all callbacks to the same type, even
when they have different arities.  Turn off the gcc warning for this
gross behavior.