### PR TITLE
[travis] Downgrade Fedora from rawhide to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ services:
 env:
   - DISTRO=debian:sid COMPILER=gcc
   - DISTRO=debian:sid COMPILER=gcc BUILTIN=yes
-  - DISTRO=fedora:rawhide COMPILER=gcc
-  - DISTRO=fedora:rawhide COMPILER=clang
+  - DISTRO=fedora:latest COMPILER=gcc
+  - DISTRO=fedora:latest COMPILER=clang
   - DISTRO=centos:7 COMPILER=gcc
 
 script:


### PR DESCRIPTION
Rawhide currently is having trouble with conflicts around gdbm.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>