### PR TITLE
Fix bashisms in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,15 +82,15 @@ AC_ARG_WITH([libevent],
 
 # Ensure that if a builtin is chosen only one is built
 BUILTIN_MODULE=
-if test x$WITH_GLIB == xbuiltin; then
+if test x$WITH_GLIB = xbuiltin; then
   BUILTIN_MODULE=glib
   WITH_LIBEV=no
   WITH_LIBEVENT=no
-elif test x$WITH_LIBEV == xbuiltin; then
+elif test x$WITH_LIBEV = xbuiltin; then
   BUILTIN_MODULE=libev
   WITH_LIBGLIB=no
   WITH_LIBEVENT=no
-elif test x$WITH_LIBEVENT == xbuiltin; then
+elif test x$WITH_LIBEVENT = xbuiltin; then
   BUILTIN_MODULE=libevent
   WITH_LIBGLIB=no
   WITH_LIBEV=no
@@ -101,20 +101,20 @@ if test x$BUILTIN_MODULE != x; then
 fi
 
 # Ensure that there is only one default (convert duplicate default to yes)
-if test x$WITH_GLIB == xdefault; then
+if test x$WITH_GLIB = xdefault; then
   AC_DEFINE([DEFUALT_MODULE], [glib])
-  test x$WITH_LIBEV    == xdefault && WITH_LIBEV=yes
-  test x$WITH_LIBEVENT == xdefault && WITH_LIBEVENT=yes
+  test x$WITH_LIBEV    = xdefault && WITH_LIBEV=yes
+  test x$WITH_LIBEVENT = xdefault && WITH_LIBEVENT=yes
 fi
-if test x$WITH_LIBEV == xdefault; then
+if test x$WITH_LIBEV = xdefault; then
   AC_DEFINE([DEFUALT_MODULE], [libev])
-  test x$WITH_LIBGLIB  == xdefault && WITH_GLIB=yes
-  test x$WITH_LIBEVENT == xdefault && WITH_LIBEVENT=yes
+  test x$WITH_LIBGLIB  = xdefault && WITH_GLIB=yes
+  test x$WITH_LIBEVENT = xdefault && WITH_LIBEVENT=yes
 fi
-if test x$WITH_LIBEVENT == xdefault; then
+if test x$WITH_LIBEVENT = xdefault; then
   AC_DEFINE([DEFUALT_MODULE], [libevent])
-  test x$WITH_GLIB     == xdefault && WITH_GLIB=yes
-  test x$WITH_LIBEV    == xdefault && WITH_LIBEV=yes
+  test x$WITH_GLIB     = xdefault && WITH_GLIB=yes
+  test x$WITH_LIBEV    = xdefault && WITH_LIBEV=yes
 fi
 
 BUILD_GLIB=no
@@ -124,7 +124,7 @@ BUILD_LIBEVENT=no
 if test x$WITH_GLIB != xno; then
   PKG_CHECK_MODULES([glib], [glib-2.0], [BUILD_GLIB=$WITH_GLIB],
                     [test x$WITH_GLIB != xauto && AC_MSG_ERROR("glib not found")])
-  if test x$BUILD_GLIB == xauto; then
+  if test x$BUILD_GLIB = xauto; then
     BUILD_GLIB=yes
   fi
 fi
@@ -138,7 +138,7 @@ if test x$WITH_LIBEV != xno; then
     ),
     [test x$WITH_LIBEV != xauto && AC_MSG_ERROR("ev.h not found")]
   )
-  if test x$BUILD_LIBEV == xauto; then
+  if test x$BUILD_LIBEV = xauto; then
     BUILD_LIBEV=yes
   fi
 fi
@@ -146,17 +146,17 @@ fi
 if test x$WITH_LIBEVENT != xno; then
   PKG_CHECK_MODULES([libevent], [libevent >= 2.0], [BUILD_LIBEVENT=$WITH_LIBEVENT],
                     [test x$WITH_LIBEVENT != xauto && AC_MSG_ERROR("libevent not found")])
-  if test x$BUILD_LIBEVENT == xauto; then
+  if test x$BUILD_LIBEVENT = xauto; then
     BUILD_LIBEVENT=yes
   fi
 fi
 
-AM_CONDITIONAL([MODULE_GLIB],      [test x$BUILTIN_MODULE == x && test x$BUILD_GLIB     != xno])
-AM_CONDITIONAL([MODULE_LIBEV],     [test x$BUILTIN_MODULE == x && test x$BUILD_LIBEV    != xno])
-AM_CONDITIONAL([MODULE_LIBEVENT],  [test x$BUILTIN_MODULE == x && test x$BUILD_LIBEVENT != xno])
-AM_CONDITIONAL([BUILTIN_GLIB],     [test x$BUILTIN_MODULE == xglib])
-AM_CONDITIONAL([BUILTIN_LIBEV],    [test x$BUILTIN_MODULE == xlibev])
-AM_CONDITIONAL([BUILTIN_LIBEVENT], [test x$BUILTIN_MODULE == xlibevent])
+AM_CONDITIONAL([MODULE_GLIB],      [test x$BUILTIN_MODULE = x && test x$BUILD_GLIB     != xno])
+AM_CONDITIONAL([MODULE_LIBEV],     [test x$BUILTIN_MODULE = x && test x$BUILD_LIBEV    != xno])
+AM_CONDITIONAL([MODULE_LIBEVENT],  [test x$BUILTIN_MODULE = x && test x$BUILD_LIBEVENT != xno])
+AM_CONDITIONAL([BUILTIN_GLIB],     [test x$BUILTIN_MODULE = xglib])
+AM_CONDITIONAL([BUILTIN_LIBEV],    [test x$BUILTIN_MODULE = xlibev])
+AM_CONDITIONAL([BUILTIN_LIBEVENT], [test x$BUILTIN_MODULE = xlibevent])
 
 AC_MSG_NOTICE()
 AC_MSG_NOTICE([BUILD CONFIGURATION])


### PR DESCRIPTION
Fix bashisms in configure.ac

'==' is not supported in POSIX shells. = is equivalent for us, so let's
use that instead.

This led to breakage when using e.g. dash as the system shell (rather than Bash)
as it caused support for e.g. gssproxy to be misdetected and broken binaries
were produced.

Bug: https://bugs.gentoo.org/762823
Signed-off-by: Sam James <sam@gentoo.org>
