### PR TITLE
Call module_close() after freeing the string name to avoid a segfault

### DIFF
--- a/src/verto.c
+++ b/src/verto.c
@@ -613,10 +613,10 @@ verto_cleanup(void)
     module_record *record;
 
     mutex_lock(&loaded_modules_mutex);
-
+    
     for (record = loaded_modules; record; record = record->next) {
-        module_close(record->dll);
         free(record->filename);
+        module_close(record->dll);
     }
 
     vfree(loaded_modules);


### PR DESCRIPTION
In the existing order there is a valgrind confirmed segfault when we free `record->filename` after the module was closed.

~~Will test this some more too!~~ Tests pass locally. 